### PR TITLE
docs(spec): add YAML front matter to all spec files and enforce hard gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,22 @@ Files in `docs/specification/` must follow the format: `<category>-<slug>.md`
 - `ux-`: User flows and interface designs.
 - `api-`: Backend/API specific constraints.
 
+### 3. Specification Front Matter & Hard Gate Enforcement
+
+All files in `docs/specification/` MUST include a YAML Front Matter block at the top.
+
+Example:
+---
+title: "Identification Engine"
+description: "Biometric matching logic and Selfie/Bib upload flows."
+type: "biz"
+epic: "seeker"
+status: "approved"
+related_issues: ["UC02"]
+---
+
+**CRITICAL RULE FOR CLAUDE CODE:** Before writing ANY implementation code, you must read the related `.md` spec. If the `status` in the Front Matter is `draft` or `in-review`, you MUST STOP and refuse to write code until the user changes it to `approved`. This is the `<HARD-GATE>` in action.
+
 ## Process Flow (DOT)
 ```dot
 digraph brainstorming {

--- a/docs/intelligence/kapt_context_skill.md
+++ b/docs/intelligence/kapt_context_skill.md
@@ -1,3 +1,11 @@
+---
+title: "Kapt Project Governance & Context"
+description: "Diretrizes primárias de governança, stack e comunicação para a IA."
+type: "tech"
+epic: "platform"
+status: "approved"
+---
+
 # Gemini Skill: Kapt Project Governance & Context
 
 ## 1. Project Mission

--- a/docs/specification/biz-model.md
+++ b/docs/specification/biz-model.md
@@ -1,3 +1,12 @@
+---
+title: "Business Model Canvas"
+description: "Visão geral do modelo de negócios, monetização, propostas de valor e segmentos de clientes do Kapt."
+type: "biz"
+epic: "platform"
+status: "approved"
+related_issues: []
+---
+
 # Business Model Canvas: Kapt
 
 ## 1. Customer Segments

--- a/docs/specification/biz-product.md
+++ b/docs/specification/biz-product.md
@@ -1,3 +1,12 @@
+---
+title: "Product Specification"
+description: "Definição do produto, personas principais (Fotógrafo e Atleta) e jornadas de uso do Kapt."
+type: "biz"
+epic: "platform"
+status: "approved"
+related_issues: []
+---
+
 # Product Specification: Kapt ⚡
 
 ## 1. Executive Summary

--- a/docs/specification/tech-core.md
+++ b/docs/specification/tech-core.md
@@ -1,3 +1,12 @@
+---
+title: "Kapt Infrastructure & Engineering"
+description: "Padrões de arquitetura, stack tecnológico, banco de dados e metas de performance."
+type: "tech"
+epic: "platform"
+status: "approved"
+related_issues: []
+---
+
 # Tech Spec: Kapt Infrastructure & Engineering
 
 ## 1. Monorepo & Package Management

--- a/docs/specification/ux-seeker-id.md
+++ b/docs/specification/ux-seeker-id.md
@@ -1,3 +1,12 @@
+---
+title: "Seeker Identification & Privacy Flow"
+description: "Fluxo arquitetural de busca por biometria/bib e implementação da barreira de privacidade (LGPD)."
+type: "ux"
+epic: "seeker"
+status: "approved"
+related_issues: ["UC02", "UC03"]
+---
+
 # Spec: Seeker Identification & Privacy Flow
 
 ## 1. Context & Objectives


### PR DESCRIPTION
## Summary

- **YAML Front Matter** added to all 5 spec/intelligence files with `title`, `description`, `type`, `epic`, `status: approved`, and `related_issues`
- **CLAUDE.md §3** — new section defining the Front Matter standard and the `<HARD-GATE>` enforcement rule: Claude Code must read the related spec before any implementation and refuse to proceed if `status` is `draft` or `in-review`

## Files changed

| File | Change |
|---|---|
| `CLAUDE.md` | Added §3 — Specification Front Matter & Hard Gate Enforcement |
| `docs/specification/biz-model.md` | Added YAML front matter |
| `docs/specification/biz-product.md` | Added YAML front matter |
| `docs/specification/tech-core.md` | Added YAML front matter |
| `docs/specification/ux-seeker-id.md` | Added YAML front matter |
| `docs/intelligence/kapt_context_skill.md` | Added YAML front matter |

## Test plan

- [ ] Confirm all spec files parse correctly with a YAML linter
- [ ] Verify `status: approved` is present on all files before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)