### PR TITLE
docs: update PRD, glossary and Gemini skill to v2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,14 +9,14 @@ related_issues: []
 
 ## 📖 Glossary & Entities (Strict Camel Case Enforced)
 
-- `occurrence`: The central domain entity. Represents a physical event (race, cycling, etc.).
-- `seeker`: The guest end-user/athlete searching for photos.
+- `occurrence`: The central domain entity. Represents a physical event/cobertura.
+- `seeker`: The guest end-user/athlete (end consumer).
 - `registeredSeeker`: A returning athlete with saved biometrics and LGPD opt-in.
-- `promoter`: The event organizer/race director (B2B target).
-- `photographer`: The freelance supplier of photos.
-- `actionVolt`: Our Design System (Dark mode, electric neon, high contrast).
+- `promoter`: The event organizer/race director.
+- `photographer`: The professional "Creator" supplying photos.
+- `actionVolt`: Our Design System (Black #000000 + Volt #CEFF00 accent).
 - **Kaptured:** A photo successfully processed and identified.
-- **B-roll / Context:** Atmosphere photos (scenery, medals). Bundled into the "Pack de Recordação" (UI Label).
+- **B-roll / Context:** Atmosphere photos (scenery, medals). Bundled into the "Pack de Recordação."
 
 ## 🚀 Business Rules & Core Logic (The "Kapt Constitution")
 
@@ -24,14 +24,13 @@ related_issues: []
 
 - **Strict Prohibition:** No public galleries showing identifiable faces.
 - **The Wall:** "Kaptured" photos are granted ONLY after Identification and LGPD Opt-in.
-- **Zero-Click Discovery:** A logged-in `registeredSeeker` automatically sees their photos under "🔒 Sua Galeria Privada".
+- **Zero-Click Discovery:** A logged-in `registeredSeeker` automatically sees their photos under "🔒 Sua Galeria Privada."
 
-### 2. Monetization (DaaS Architecture)
+### 2. Monetization (DaaS Evolution)
 
-- **DaaS Tiers:** We extract gear wear and brand loyalty to sell B2B reports (Tier 1), Ads (Tier 2), and APIs (Tier 3).
-- **Photographer Incentives:** - +5% payout bonus for clear gear detection (Paid ONLY if the photo sells).
-  - Fixed LGPD Bounty (e.g., R$ 5.00) for uploading the first 20 B-roll photos.
-- **Upsell Rule:** B-roll is never sold solo. It is used to anchor the "Pack de Recordação" price.
+- **DaaS Tiers:** We extract gear wear, brand loyalty, and "wearing" states to sell hyper-segmented insights to brands.
+- **Photographer Incentives:** +5% payout bonus for clear gear detection (Paid ONLY if the photo sells).
+- **Upsell Rule:** B-roll is never sold solo. It anchors the "Pack de Recordação" price.
 
 ### 3. Localization & UI State (PT-BR)
 

--- a/docs/PRD-Executivo.md
+++ b/docs/PRD-Executivo.md
@@ -7,62 +7,47 @@ status: "approved"
 ai_instruction: "DO NOT use this file for code generation. Refer to the specific /specification/*.md files for SDD."
 ---
 
-📖 Master Product Requirements Document (PRD) - Kapt
+## Master Product Requirements Document (PRD) - Kapt (v2.0)
 
-1. Product Vision (Elevator Pitch)
-Kapt is not just a sports photography marketplace. It is a B2B DaaS (Data-as-a-Service) platform disguised as a B2C photography e-commerce. We use photo sales as a vehicle to capture, process via AI (Computer Vision), and structure valuable sports retail data (brands, equipment, wear and tear), selling this intelligence to the market.
+## 1. Project Identity & Mission Statement
 
-2. Official Kapt Glossary
-To maintain consistency across code and communication, these are the immutable system entities (using Camel Case for technical references):
+Kapt is a high-performance digital platform for the management, distribution, and monetization of official multisport event photography. By leveraging Computer Vision (CV) and AI, Kapt automates the bridge between professional "Creators" (photographers) and athletes. Its ultimate evolution is a **Data as a Service (DaaS)** provider, delivering hyper-segmented consumer insights—based on actual performance and equipment usage—to sports retailers and brands.
 
-seeker: The athlete/runner (the end customer who buys the photo).
+## 2. Core Features & AI Capabilities
 
-registeredSeeker: A returning athlete who already has an account, saved biometrics, and LGPD opt-in.
+- **AI-Driven Automated Tagging:**
+    - **Facial Recognition:** High-precision identification of athletes across thousands of photos.
+    - **Equipment & Brand Detection:** Automatic identification of footwear (running shoes), apparel, and gear (bikes, helmets, watches).
+- **"Wearing" State & Analytics:** Analysis of brand loyalty, equipment wear-and-tear levels, and color preferences to generate consumer profiles.
+- **Multisport Mosaic Interface:** Dynamic, responsive home screen utilizing high-density image grids for active "Coberturas."
+- **Secure OTP Authentication:** Passwordless, friction-free login flow via email/mobile.
+- **DaaS Market Intelligence:** Aggregated data on brand dominance, gear lifespan, and demographic equipment trends.
 
-occurrence: The sporting event (e.g., Maratona SP, Corrida de São Luís).
+## 3. Technical Stack & Architecture
 
-promoter: The event organizer/race director.
+- **Frontend:** Next.js (App Router), TypeScript, Tailwind CSS.
+- **Backend:** Go (Golang) for high-concurrency API and data processing.
+- **AI/ML Engine (Python):** YOLO (object/gear detection), DeepFace/FaceNet (facial recognition), PyTorch/TensorFlow (segmentation).
+- **Orchestration:** n8n manages the pipeline (uploads -> AI -> notifications).
+- **Infrastructure:** Docker, Portainer, Traefik/Nginx, Neon (PostgreSQL) + PostGIS.
 
-photographer: The freelance photographer (our supplier).
+## 4. Design Style Guide (Black & Volt)
 
-actionVolt: Our Design System (UI/UX in Dark Mode with neon/electric details for high contrast and premium aesthetics).
+- **Palette:** Background: Absolute Black (#000000); Accent: Volt (#CEFF00) for CTAs; Secondary: Zinc Grays.
+- **Typography:** Brand: Heavy, italicized bold "KAPT"; Functional: Monospaced for technical labels (e.g., "COBERTURAS").
 
-1. Monetization Architecture (How Kapt makes money)
-The Base (B2C - Marketplace): Sale of individual photos or the complete package (UI Label: "Pack de Recordação") directly to the seeker.
+## 5. Evolution Phases
 
-Tier 1 (B2B - Reports): Providing profile and equipment data to the promoter, allowing them to sell more expensive sponsorship quotas.
+- **Phase 1 (Current):** Infrastructure stabilization. Next.js + Go core, basic gallery, and OTP authentication.
+- **Phase 2 (AI Integration):** Implementation of automated facial and bib-number recognition. Launch of the "Creator Dashboard."
+- **Phase 3 (Apparel & Gear Analytics):** Deployment of CV models to detect equipment brands and "wearing" states.
+- **Phase 4 (DaaS Full Launch):** Real-time dashboarding and predictive analytics for retailers.
 
-Tier 2 (B2B - Targeted Advertising): Kapt sells "Access" to brands (e.g., Asics pays to send a coupon to registeredSeekers who ran with worn-out shoes).
+## 6. Official Glossary
 
-Tier 3 (B2B - Infrastructure/API): Licensing our real-time image processing API to retail giants (e.g., Centauro) to create campaigns in their own apps.
-
-1. Photographer Journey (Supply)
-The goal is to retain the supplier through zero friction and financial gamification.
-
-Zero-Touch Upload: The photographer simply drags the folder. The system processes everything in the background.
-
-Post-Upload Report (Dopamine Trigger): At the end of the upload, we display a summary showing how much equipment the AI detected and the potential extra earnings tied to that reading.
-
-Conditional Commission (Cash Protection): The photographer receives the AI bonus (+5%) for photos where equipment was detected only if the photo is purchased by the seeker.
-
-The B-Roll Rule (LGPD Bounty): To ensure the public showcase of the event without violating the LGPD, we pay a fixed micro-bonus (e.g., R$ 5.00) for the first 20 context photos (asphalt, finish line, medals) uploaded.
-
-1. Seeker Journey (Demand)
-The goal is maximum conversion with zero unnecessary clicks.
-
-Zero-Click Discovery (The Magic): If the user is a registeredSeeker and logged in, the backend matches their biometrics on page load. Their photos immediately appear at the top of the occurrence page in a section labeled "🔒 Sua Galeria Privada".
-
-Frictionless Onboarding: Passwordless authentication modal (Email/WhatsApp + 4-digit OTP), followed immediately by a selfie request. No long forms.
-
-Upsell Strategy (Pack de Recordação): B-roll is never sold individually. It is used as leverage. The seeker can buy a single photo (e.g., R$ 15.00) or be induced to take all their photos + all the event's B-roll (UI Label: "Pack de Recordação") for an anchored price (e.g., R$ 39.90).
-
-Storage Management: Delivery focuses on the cloud gallery. If the user wants the complete Pack, we send a link to a .zip file via email so we don't crash their mobile device storage.
-
-1. Expansion Strategy (Occurrences)
-Kapt owns the calendar to avoid depending on the promoter in the early stages.
-
-Phase 1 (MVP - São Luís): Manual insertion of occurrences by our internal team (Control and Quality).
-
-Phase 2 (Scale): Use of ScrapingBee to pull national calendars (TicketSports, etc.) and automatically populate our database.
-
-Empty States (Contingency): If a race has no B-roll from the photographer, the page collapses the public showcase and the event card gets a dynamic abstract cover based on the sport (UI Fallback).
+- `seeker`: The athlete/runner (end consumer).
+- `registeredSeeker`: A returning athlete with saved biometrics and LGPD opt-in.
+- `occurrence`: The sporting event.
+- `promoter`: The event organizer.
+- `photographer`: The professional "Creator" supplying photos.
+- `actionVolt`: Our Design System (Table Black + Volt accent).

--- a/docs/intelligence/kapt_context_skill.md
+++ b/docs/intelligence/kapt_context_skill.md
@@ -6,39 +6,42 @@ epic: "platform"
 status: "approved"
 ---
 
-# Gemini Skill: Kapt Project Governance & Context
+## Gemini Skill: Kapt Project Governance & Context (v2.0)
 
 ## 1. Project Mission & Identity
 
-Kapt is a **B2B DaaS (Data-as-a-Service) platform disguised as a B2C sports photography e-commerce**. It connects athletes and photographers through AI-driven search (OCR, Facial Recognition, PostGIS), while structuring valuable retail data (brands, gear wear) to sell to the market.
+Kapt is a **high-performance digital platform for the management, distribution, and monetization of official multisport event photography**. Evolving into a **DaaS (Data as a Service)** provider, it delivers hyper-segmented consumer insights based on performance and equipment usage to sports retailers and brands.
 
-## 2. Technical Stack & Standards
+## 2. Technical Stack & AI Intelligence
 
-- **Monorepo:** Turborepo with **npm** as the package manager.
-- **Frontend:** Next.js 16 (located in `/apps/web`).
-- **Backend:** Go 1.22+ using native `net/http` (located in `/services/api`).
-- **Database:** Neon (PostgreSQL) + PostGIS + SQLC for type-safe queries.
-- **Methodology:** Spec-Driven Development (SDD). All code must align with `/.spec`.
+- **Frontend:** Next.js (App Router), TypeScript, Tailwind CSS.
+- **Backend:** Go (Golang) for high-concurrency API and data processing.
+- **AI/ML Engine (Python):** 
+  - **Models:** YOLO for object/gear detection; DeepFace/FaceNet for facial recognition; PyTorch/TensorFlow for apparel segmentation.
+  - **Orchestration:** n8n manages the pipeline between uploads, AI triggers, and notifications.
+- **Infrastructure:** Docker, Portainer, Traefik/Nginx, Neon (PostgreSQL) + PostGIS.
 
-## 3. Official Glossary (Strict Camel Case for Code)
+## 3. Official Glossary (Strict Camel Case)
 
-- `seeker`: The athlete/runner (first-time or anonymous). NEVER use generic "User".
+- `seeker`: The athlete/runner (end consumer).
 - `registeredSeeker`: A returning athlete with saved biometrics and LGPD opt-in.
-- `occurrence`: The sporting event. NEVER use "Event", "Race" or "Match".
-- `promoter`: The event organizer/race director.
-- `photographer`: The freelance photographer supplying the photos.
-- `actionVolt`: Our Design System (Dark mode, neon/electric details, premium high-contrast).
+- `occurrence`: The sporting event/cobertura.
+- `promoter`: The event organizer.
+- `photographer`: The professional "Creator" supplying photos.
+- `actionVolt`: Our Design System (Table Black #000000, Volt #CEFF00 accent).
 
-## 4. Product & UX Philosophy
+## 4. Evolution Roadmap
 
-- **Zero-Click Discovery:** A `registeredSeeker` must find their photos magically via biometrics on page load, with zero friction.
-- **Cash Protection:** Photographer AI bonuses are paid ONLY upon the photo's sale.
-- **Upsell Leverage:** B-roll context photos are NEVER sold individually. They are bundled into the "Pack de Recordação" to increase AOV (Average Order Value).
+1. **Phase 1 (Current):** Infrastructure stabilization (Next.js + Go core, basic gallery, OTP auth).
+2. **Phase 2 (AI Integration):**
+  - **AI-Driven Automated Tagging:**
+    - **Facial Recognition:** High-precision identification of athletes across thousands of photos.
+    - **Equipment & Brand Detection:** Automatic identification of footwear (running shoes), apparel, and gear (bikes, helmets, watches).
+4. **Phase 4 (DaaS Launch):** Predictive analytics and real-time dashboards for retailers.
 
-## 5. Directory Governance & Communication
+## 5. Development Standards
 
-- Always use the `cmd/api` and `internal/` pattern for Go services.
-- Keep the project root clean; orchestration files only.
-- **Technical Specs:** Always in English for precision.
-- **UI Labels:** Always in Portuguese (target market: Brazil).
-- **Tone:** Professional, "cool", rich vocabulary, and performance-oriented.
+- **Methodology:** Spec-Driven Development (SDD). All code must align with `docs/specification/`.
+- **UI/UX:** Focus on "Zero-Click Discovery" and premium "Multisport Mosaic" interfaces.
+- **Security:** JWT + OTP for passwordless sessions.
+- **Localization:** UI labels in PT-BR; technical specs in English.


### PR DESCRIPTION
## Summary

- Refines entity definitions across `CLAUDE.md`, `PRD-Executivo.md`, and `kapt_context_skill.md`
- Expands DaaS roadmap with Phase 1–4 evolution steps
- Aligns product vision with the current Black & Volt design direction and multisport identity
- Cleans up redundant sections in the PRD for a more concise, actionable document

## Test plan

- [x] Review `CLAUDE.md` glossary entries for accuracy
- [x] Review `PRD-Executivo.md` v2.0 structure and phase descriptions
- [x] Review `kapt_context_skill.md` for consistency with CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)