### PR TITLE
feat(seeker): implement SelfieCapture component with LGPD opt-in flow

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { OccurrenceCard } from '@/components/OccurrenceCard';
 import { OTPModal } from '@/components/OTPModal';
+import { SelfieCapture } from '@/components/SelfieCapture';
 import { Navbar } from '@/components/Navbar';
 import { MOCK_OCCURRENCES } from '@/mocks/occurrences';
 
@@ -17,10 +18,12 @@ const presentation_images = [
 
 export default function Page() {
   const [isOTPOpen, setIsOTPOpen] = useState(false);
+  const [isSelfieCaptureOpen, setIsSelfieCaptureOpen] = useState(false);
 
   const handleAuthSuccess = (token: string) => {
     localStorage.setItem('kapt_token', token);
     setIsOTPOpen(false);
+    setIsSelfieCaptureOpen(true);
   };
 
   return (
@@ -29,6 +32,11 @@ export default function Page() {
         isOpen={isOTPOpen}
         onClose={() => setIsOTPOpen(false)}
         onSuccess={handleAuthSuccess}
+      />
+      <SelfieCapture
+        isOpen={isSelfieCaptureOpen}
+        onClose={() => setIsSelfieCaptureOpen(false)}
+        onSuccess={() => setIsSelfieCaptureOpen(false)}
       />
 
       {/* Header: Brand Identity and Top-Aligned Navigation */}

--- a/apps/web/src/components/SelfieCapture.test.tsx
+++ b/apps/web/src/components/SelfieCapture.test.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { SelfieCapture } from '@/components/SelfieCapture';
+import * as api from '@/lib/api';
+
+// ─── MediaDevices mock ────────────────────────────────────────────────────────
+
+const mockTrackStop = jest.fn();
+const mockGetUserMedia = jest.fn();
+
+beforeAll(() => {
+    Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+        writable: true,
+        value: { getUserMedia: mockGetUserMedia },
+    });
+
+    // jsdom has no HTMLVideoElement.play; silence the error
+    Object.defineProperty(HTMLVideoElement.prototype, 'play', {
+        writable: true,
+        value: jest.fn(),
+    });
+});
+
+function makeMockStream() {
+    return {
+        getTracks: () => [{ stop: mockTrackStop }],
+    } as unknown as MediaStream;
+}
+
+// ─── api mock ─────────────────────────────────────────────────────────────────
+
+jest.mock('@/lib/api', () => ({
+    ...jest.requireActual('@/lib/api'),
+    submitSelfie: jest.fn(),
+}));
+const mockedSubmitSelfie = api.submitSelfie as jest.MockedFunction<typeof api.submitSelfie>;
+
+// ─── canvas mock ──────────────────────────────────────────────────────────────
+
+beforeAll(() => {
+    HTMLCanvasElement.prototype.toBlob = function (cb) {
+        cb(new Blob(['fake'], { type: 'image/jpeg' }));
+    };
+    HTMLCanvasElement.prototype.toDataURL = () => 'data:image/jpeg;base64,fake';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    HTMLCanvasElement.prototype.getContext = (() => ({ drawImage: jest.fn() })) as any;
+});
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+const defaultProps = {
+    isOpen: true,
+    onClose: jest.fn(),
+    onSuccess: jest.fn(),
+};
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mockGetUserMedia.mockResolvedValue(makeMockStream());
+});
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+describe('SelfieCapture', () => {
+    it('renders camera step with "Tirar foto" button when permission granted', async () => {
+        render(<SelfieCapture {...defaultProps} />);
+        await waitFor(() => {
+            expect(screen.getByRole('button', { name: /tirar foto/i })).toBeInTheDocument();
+        });
+    });
+
+    it('shows PT-BR error when camera permission is denied', async () => {
+        mockGetUserMedia.mockRejectedValue(new DOMException('denied', 'NotAllowedError'));
+        render(<SelfieCapture {...defaultProps} />);
+        await waitFor(() => {
+            expect(screen.getByRole('alert')).toHaveTextContent(
+                'Permissão de câmera negada',
+            );
+        });
+    });
+
+    it('advances to consent step after capture', async () => {
+        render(<SelfieCapture {...defaultProps} />);
+        await waitFor(() => screen.getByRole('button', { name: /tirar foto/i }));
+
+        fireEvent.click(screen.getByRole('button', { name: /tirar foto/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText('Consentimento LGPD')).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /confirmar/i })).toBeInTheDocument();
+        });
+    });
+
+    it('defaults to Global consent and allows switching to Evento-específico', async () => {
+        render(<SelfieCapture {...defaultProps} />);
+        await waitFor(() => screen.getByRole('button', { name: /tirar foto/i }));
+        fireEvent.click(screen.getByRole('button', { name: /tirar foto/i }));
+        await waitFor(() => screen.getByRole('button', { name: /confirmar/i }));
+
+        const globalRadio = screen.getByRole('radio', { name: /global/i });
+        const eventRadio = screen.getByRole('radio', { name: /evento-específico/i });
+
+        expect(globalRadio).toBeChecked();
+        expect(eventRadio).not.toBeChecked();
+
+        fireEvent.click(eventRadio);
+        expect(eventRadio).toBeChecked();
+        expect(globalRadio).not.toBeChecked();
+    });
+
+    it('calls submitSelfie with correct args and triggers onSuccess', async () => {
+        jest.useFakeTimers();
+        localStorage.setItem('kapt_token', 'test-jwt');
+        mockedSubmitSelfie.mockResolvedValue(undefined);
+
+        render(<SelfieCapture {...defaultProps} />);
+        await waitFor(() => screen.getByRole('button', { name: /tirar foto/i }));
+        fireEvent.click(screen.getByRole('button', { name: /tirar foto/i }));
+        await waitFor(() => screen.getByRole('button', { name: /confirmar/i }));
+
+        fireEvent.click(screen.getByRole('button', { name: /confirmar/i }));
+
+        await waitFor(() => {
+            expect(mockedSubmitSelfie).toHaveBeenCalledWith(
+                expect.any(Blob),
+                'global',
+                'test-jwt',
+            );
+        });
+
+        await waitFor(() => expect(screen.getByText(/fotos sendo buscadas/i)).toBeInTheDocument());
+
+        act(() => jest.runAllTimers());
+        expect(defaultProps.onSuccess).toHaveBeenCalledTimes(1);
+        jest.useRealTimers();
+    });
+
+    it('shows PT-BR error message on API failure', async () => {
+        mockedSubmitSelfie.mockRejectedValue(new api.ApiError(500, 'server error'));
+
+        render(<SelfieCapture {...defaultProps} />);
+        await waitFor(() => screen.getByRole('button', { name: /tirar foto/i }));
+        fireEvent.click(screen.getByRole('button', { name: /tirar foto/i }));
+        await waitFor(() => screen.getByRole('button', { name: /confirmar/i }));
+        fireEvent.click(screen.getByRole('button', { name: /confirmar/i }));
+
+        await waitFor(() => {
+            expect(screen.getByRole('alert')).toHaveTextContent(
+                'Não foi possível enviar sua selfie',
+            );
+        });
+    });
+
+    it('closes when backdrop is clicked', async () => {
+        render(<SelfieCapture {...defaultProps} />);
+        fireEvent.click(screen.getByLabelText('Fechar captura'));
+        expect(defaultProps.onClose).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/web/src/components/SelfieCapture.tsx
+++ b/apps/web/src/components/SelfieCapture.tsx
@@ -1,0 +1,281 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { X, Loader2, CheckCircle2, CameraOff } from 'lucide-react';
+import { submitSelfie, ApiError } from '@/lib/api';
+
+export interface SelfieCaptureProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onSuccess: () => void;
+}
+
+type Step = 'camera' | 'consent' | 'submitting' | 'success' | 'error';
+type ConsentType = 'global' | 'event';
+
+export const SelfieCapture = ({ isOpen, onClose, onSuccess }: SelfieCaptureProps) => {
+    const [step, setStep] = useState<Step>('camera');
+    const [consentType, setConsentType] = useState<ConsentType>('global');
+    const [capturedBlob, setCapturedBlob] = useState<Blob | null>(null);
+    const [capturedPreview, setCapturedPreview] = useState<string | null>(null);
+    const [permissionDenied, setPermissionDenied] = useState(false);
+    const [errorMsg, setErrorMsg] = useState('');
+
+    const videoRef = useRef<HTMLVideoElement>(null);
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const streamRef = useRef<MediaStream | null>(null);
+
+    const stopStream = useCallback(() => {
+        streamRef.current?.getTracks().forEach((t) => t.stop());
+        streamRef.current = null;
+    }, []);
+
+    const startCamera = useCallback(async () => {
+        setPermissionDenied(false);
+        try {
+            const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'user' } });
+            streamRef.current = stream;
+            if (videoRef.current) {
+                videoRef.current.srcObject = stream;
+            }
+        } catch (err) {
+            if (err instanceof DOMException && err.name === 'NotAllowedError') {
+                setPermissionDenied(true);
+            }
+        }
+    }, []);
+
+    useEffect(() => {
+        if (isOpen) {
+            setStep('camera');
+            setConsentType('global');
+            setCapturedBlob(null);
+            setCapturedPreview(null);
+            setPermissionDenied(false);
+            setErrorMsg('');
+            startCamera();
+        } else {
+            stopStream();
+        }
+        return () => stopStream();
+    }, [isOpen, startCamera, stopStream]);
+
+    const handleCapture = () => {
+        const video = videoRef.current;
+        const canvas = canvasRef.current;
+        if (!video || !canvas) return;
+
+        canvas.width = video.videoWidth;
+        canvas.height = video.videoHeight;
+        canvas.getContext('2d')?.drawImage(video, 0, 0);
+
+        canvas.toBlob((blob) => {
+            if (!blob) return;
+            setCapturedBlob(blob);
+            setCapturedPreview(canvas.toDataURL('image/jpeg'));
+            stopStream();
+            setStep('consent');
+        }, 'image/jpeg', 0.9);
+    };
+
+    const handleSubmit = async () => {
+        if (!capturedBlob) return;
+        setStep('submitting');
+        const token = localStorage.getItem('kapt_token') ?? '';
+        try {
+            await submitSelfie(capturedBlob, consentType, token);
+            setStep('success');
+            setTimeout(onSuccess, 1000);
+        } catch (err) {
+            setErrorMsg(
+                err instanceof ApiError && err.status === 401
+                    ? 'Sessão expirada. Faça login novamente.'
+                    : 'Não foi possível enviar sua selfie. Tente novamente.',
+            );
+            setStep('error');
+        }
+    };
+
+    const handleRetake = () => {
+        setCapturedBlob(null);
+        setCapturedPreview(null);
+        setStep('camera');
+        startCamera();
+    };
+
+    if (!isOpen) return null;
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+            onClick={onClose}
+            aria-label="Fechar captura"
+        >
+            <div
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="selfie-modal-title"
+                className="relative w-full max-w-sm mx-4 bg-pavement border border-white/10 rounded-card p-8 shadow-2xl"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <button
+                    onClick={onClose}
+                    className="absolute top-4 right-4 text-zinc-500 hover:text-white transition-colors"
+                    aria-label="Fechar"
+                >
+                    <X size={18} />
+                </button>
+
+                {/* Header */}
+                <div className="mb-6">
+                    <p className="text-zinc-500 text-[10px] uppercase tracking-widest font-semibold mb-1">
+                        Identificação
+                    </p>
+                    <h2 id="selfie-modal-title" className="text-white text-2xl font-black tracking-tight">
+                        {step === 'camera' && 'Tire sua selfie'}
+                        {step === 'consent' && 'Consentimento LGPD'}
+                        {step === 'submitting' && 'Enviando...'}
+                        {step === 'success' && 'Tudo certo!'}
+                        {step === 'error' && 'Algo deu errado'}
+                    </h2>
+                    {step === 'camera' && !permissionDenied && (
+                        <p className="text-zinc-400 text-sm mt-2">
+                            Posicione seu rosto no centro e clique em "Tirar foto".
+                        </p>
+                    )}
+                    {step === 'consent' && (
+                        <p className="text-zinc-400 text-sm mt-2">
+                            Confirme como deseja compartilhar seus dados biométricos.
+                        </p>
+                    )}
+                </div>
+
+                {/* Step: camera */}
+                {step === 'camera' && (
+                    permissionDenied ? (
+                        <div className="flex flex-col items-center gap-4 py-4" role="alert">
+                            <CameraOff size={40} className="text-zinc-500" />
+                            <p className="text-zinc-400 text-sm text-center">
+                                Permissão de câmera negada. Habilite o acesso nas configurações do seu navegador.
+                            </p>
+                        </div>
+                    ) : (
+                        <div className="flex flex-col gap-4">
+                            <div className="relative w-full aspect-square bg-neutral-900 rounded-lg overflow-hidden">
+                                <video
+                                    ref={videoRef}
+                                    autoPlay
+                                    playsInline
+                                    muted
+                                    className="w-full h-full object-cover scale-x-[-1]"
+                                    aria-label="Pré-visualização da câmera"
+                                />
+                            </div>
+                            <canvas ref={canvasRef} className="hidden" />
+                            <button
+                                onClick={handleCapture}
+                                className="w-full bg-volt text-black font-black text-[11px] uppercase tracking-widest rounded-lg py-3 hover:brightness-110 transition-all"
+                            >
+                                Tirar foto
+                            </button>
+                        </div>
+                    )
+                )}
+
+                {/* Step: consent */}
+                {step === 'consent' && capturedPreview && (
+                    <div className="flex flex-col gap-5">
+                        <img
+                            src={capturedPreview}
+                            alt="Sua selfie capturada"
+                            className="w-24 h-24 rounded-full object-cover mx-auto border-2 border-volt/40 scale-x-[-1]"
+                        />
+
+                        <fieldset className="flex flex-col gap-3">
+                            <legend className="text-zinc-400 text-xs uppercase tracking-widest mb-1">
+                                Tipo de consentimento
+                            </legend>
+
+                            <label className="flex items-start gap-3 cursor-pointer group">
+                                <input
+                                    type="radio"
+                                    name="consent"
+                                    value="global"
+                                    checked={consentType === 'global'}
+                                    onChange={() => setConsentType('global')}
+                                    className="mt-0.5 accent-volt"
+                                />
+                                <span className="flex flex-col">
+                                    <span className="text-white text-sm font-bold">Global</span>
+                                    <span className="text-zinc-400 text-xs">
+                                        Ganhe sua 1ª foto grátis no próximo evento
+                                    </span>
+                                </span>
+                            </label>
+
+                            <label className="flex items-start gap-3 cursor-pointer group">
+                                <input
+                                    type="radio"
+                                    name="consent"
+                                    value="event"
+                                    checked={consentType === 'event'}
+                                    onChange={() => setConsentType('event')}
+                                    className="mt-0.5 accent-volt"
+                                />
+                                <span className="flex flex-col">
+                                    <span className="text-white text-sm font-bold">Evento-específico</span>
+                                    <span className="text-zinc-400 text-xs">
+                                        Apenas para esta cobertura
+                                    </span>
+                                </span>
+                            </label>
+                        </fieldset>
+
+                        <button
+                            onClick={handleSubmit}
+                            className="w-full bg-volt text-black font-black text-[11px] uppercase tracking-widest rounded-lg py-3 hover:brightness-110 transition-all"
+                        >
+                            Confirmar
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleRetake}
+                            className="text-zinc-500 hover:text-white text-xs text-center transition-colors"
+                        >
+                            Tirar nova foto
+                        </button>
+                    </div>
+                )}
+
+                {/* Step: submitting */}
+                {step === 'submitting' && (
+                    <div className="flex flex-col items-center gap-3 py-6">
+                        <Loader2 size={36} className="animate-spin text-volt" />
+                        <p className="text-zinc-400 text-sm">Buscando suas fotos...</p>
+                    </div>
+                )}
+
+                {/* Step: success */}
+                {step === 'success' && (
+                    <div className="flex flex-col items-center gap-3 py-6">
+                        <CheckCircle2 size={40} className="text-volt" />
+                        <p className="text-white font-bold text-sm">Fotos sendo buscadas!</p>
+                    </div>
+                )}
+
+                {/* Step: error */}
+                {step === 'error' && (
+                    <div className="flex flex-col gap-4">
+                        <p role="alert" className="text-red-400 text-sm text-center">{errorMsg}</p>
+                        <button
+                            onClick={handleRetake}
+                            className="w-full bg-volt text-black font-black text-[11px] uppercase tracking-widest rounded-lg py-3 hover:brightness-110 transition-all"
+                        >
+                            Tentar novamente
+                        </button>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -32,3 +32,24 @@ export function requestOTP(contact: string): Promise<void> {
 export function verifyOTP(contact: string, code: string): Promise<{ token: string }> {
     return post<{ token: string }>('/auth/otp/verify', { contact, code });
 }
+
+export async function submitSelfie(
+    blob: Blob,
+    consentType: 'global' | 'event',
+    token: string,
+): Promise<void> {
+    const form = new FormData();
+    form.append('selfie', blob, 'selfie.jpg');
+    form.append('consent_type', consentType);
+
+    const res = await fetch(`${API_BASE}/identification/selfie`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: form,
+    });
+
+    if (!res.ok) {
+        const text = await res.text().catch(() => res.statusText);
+        throw new ApiError(res.status, text);
+    }
+}

--- a/docs/specification/ux-selfie-capture.md
+++ b/docs/specification/ux-selfie-capture.md
@@ -1,0 +1,122 @@
+---
+title: "Selfie Capture & LGPD Opt-In Flow"
+description: "Spec for the SelfieCapture modal: camera access, selfie capture, LGPD biometric consent (Global vs. Event-specific), and submission to the Identification Engine."
+type: "ux"
+epic: "seeker"
+status: "approved"
+related_issues: ["25"]
+---
+
+# UX Spec: Selfie Capture & LGPD Opt-In Flow
+
+## 1. Context & Objective
+
+After OTP authentication, the `seeker` must provide a selfie and give explicit LGPD biometric
+consent before the Identification Engine can match their photos. This modal appears immediately
+after `handleAuthSuccess` closes the `OTPModal`.
+
+---
+
+## 2. Component: `SelfieCapture`
+
+Follows the same modal pattern as `OTPModal` — centered overlay, `rounded-card`, actionVolt
+tokens, all copy in PT-BR.
+
+### Props
+
+```ts
+interface SelfieCaptureProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: () => void; // fires after successful submission
+}
+```
+
+---
+
+## 3. Step Machine
+
+```
+camera → consent → (submitting) → success | error
+```
+
+| Step | Description |
+|---|---|
+| `camera` | Request `getUserMedia` permission → live `<video>` preview → "Tirar foto" CTA |
+| `consent` | Show captured thumbnail + LGPD opt-in toggles + "Confirmar" CTA |
+| `submitting` | Spinner while POSTing to `/identification/selfie` |
+| `success` | Volt checkmark + "Fotos sendo buscadas!" → calls `onSuccess` after 1s |
+| `error` | PT-BR error message + retry option |
+
+### Camera Permission Denied
+If `getUserMedia` throws a `NotAllowedError`, display a static error state:
+- Icon: camera crossed out
+- Copy: **"Permissão de câmera negada. Habilite o acesso nas configurações do seu navegador."**
+- No retry loop — user must fix browser settings manually.
+
+---
+
+## 4. LGPD Consent Options
+
+| Type | `consent_type` value | Benefit shown to user |
+|---|---|---|
+| Global | `global` | "Ganhe sua 1ª foto grátis no próximo evento" |
+| Evento-específico | `event` | "Apenas para esta cobertura" |
+
+Default selection: **Global** (maximises opt-in rate per business rules).
+
+---
+
+## 5. API Integration
+
+### New function in `src/lib/api.ts`
+
+```ts
+submitSelfie(blob: Blob, consentType: 'global' | 'event', token: string): Promise<void>
+```
+
+**Request:**
+```
+POST /identification/selfie
+Authorization: Bearer <token>
+Content-Type: multipart/form-data
+
+selfie: <image blob>
+consent_type: 'global' | 'event'
+```
+
+**Responses:**
+- `200` → success
+- `401` → token expired, show PT-BR error
+- `5xx` → generic PT-BR error
+
+---
+
+## 6. Files Changed
+
+| File | Action |
+|---|---|
+| `apps/web/src/components/SelfieCapture.tsx` | New component |
+| `apps/web/src/components/SelfieCapture.test.tsx` | Tests |
+| `apps/web/src/lib/api.ts` | Add `submitSelfie()` |
+| `apps/web/app/page.tsx` | Open `SelfieCapture` after OTP success |
+
+---
+
+## 7. Test Coverage
+
+- Camera permission denied → shows PT-BR error state
+- Successful capture → advances to consent step
+- Consent toggle switches between Global and Evento-específico
+- Submit calls `submitSelfie` with correct args
+- Success state calls `onSuccess`
+- API error shows PT-BR error message
+
+---
+
+## 8. Success Criteria
+
+- `seeker` can capture a selfie via browser camera on mobile and desktop.
+- LGPD consent is explicitly recorded before any POST is made.
+- All copy is in PT-BR.
+- All test cases pass (`npm test` in `apps/web`).


### PR DESCRIPTION
## Summary

- Adds `SelfieCapture` modal triggered automatically after OTP authentication
- 3-step flow: **camera** (live preview + capture) → **consent** (LGPD opt-in) → **submit** (POST to identification engine)
- LGPD consent defaults to **Global** (earns 1ª foto grátis) with option for **Evento-específico**
- Camera permission denied shows a clear PT-BR error — no retry loop, user fixes browser settings
- `submitSelfie()` added to `api.ts` — multipart form with `Authorization: Bearer` token

## Test plan

- [x] Camera permission granted → "Tirar foto" button renders
- [x] Camera permission denied → PT-BR error alert shown
- [x] Capture → advances to consent step
- [x] Consent defaults to Global, switches to Evento-específico
- [x] Confirm → calls `submitSelfie` with correct blob, consent type, and token
- [x] API error → PT-BR error message shown
- [x] Backdrop click → `onClose` called
- [x] All 15 tests pass (`npx jest`)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)