### PR TITLE
fix(auth): address critical OTP fallback vulnerability and JWT PII exposure

### DIFF
--- a/services/internal/handler/auth.go
+++ b/services/internal/handler/auth.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -30,11 +31,15 @@ func (h *Handler) RequestOTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// 1. Generate a secure 6-digit numeric code
-	code := generateRandomCode(6)
+	code, err := generateRandomCode(6)
+	if err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
 
 	// 2. Persist the OTP in Neon via SQLC (Set to expire in 10 minutes)
 	// The Upsert operation ensures that any previous code for this email is replaced
-	_, err := h.repo.UpsertOTP(r.Context(), repository.UpsertOTPParams{
+	_, err = h.repo.UpsertOTP(r.Context(), repository.UpsertOTPParams{
 		Email:     payload.Email,
 		Code:      code,
 		ExpiresAt: time.Now().Add(10 * time.Minute),
@@ -115,10 +120,9 @@ func (h *Handler) VerifyOTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	claims := jwt.MapClaims{
-		"sub":   seeker.ID.String(),
-		"email": seeker.Email,
-		"iat":   time.Now().Unix(),
-		"exp":   time.Now().Add(24 * time.Hour).Unix(),
+		"sub": seeker.ID.String(),
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(24 * time.Hour).Unix(),
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	signed, err := token.SignedString([]byte(secret))
@@ -132,19 +136,20 @@ func (h *Handler) VerifyOTP(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]string{"token": signed})
 }
 
-// generateRandomCode creates a cryptographically secure numeric string
-func generateRandomCode(max int) string {
+// generateRandomCode creates a cryptographically secure numeric string.
+// Returns an error if the OS entropy source fails — callers must not fall back
+// to a predictable value.
+func generateRandomCode(max int) (string, error) {
 	var table = [...]byte{'1', '2', '3', '4', '5', '6', '7', '8', '9', '0'}
 	b := make([]byte, max)
 
-	// Use crypto/rand for secure generation instead of math/rand
-	n, _ := io.ReadAtLeast(rand.Reader, b, max)
-	if n != max {
-		return "123456" // Safety fallback in case of entropy failure
+	n, err := io.ReadAtLeast(rand.Reader, b, max)
+	if err != nil || n != max {
+		return "", fmt.Errorf("entropy failure: read %d of %d bytes: %w", n, max, err)
 	}
 
 	for i := 0; i < len(b); i++ {
 		b[i] = table[int(b[i])%len(table)]
 	}
-	return string(b)
+	return string(b), nil
 }

--- a/services/internal/handler/auth_test.go
+++ b/services/internal/handler/auth_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -122,6 +124,65 @@ func TestVerifyOTP_MalformedBody_Returns400(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestGenerateRandomCode_ReturnsCorrectLength(t *testing.T) {
+	code, err := generateRandomCode(6)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(code) != 6 {
+		t.Fatalf("expected 6 chars, got %d", len(code))
+	}
+	for _, c := range code {
+		if c < '0' || c > '9' {
+			t.Fatalf("expected numeric chars, got %q", c)
+		}
+	}
+}
+
+func TestVerifyOTP_JWTDoesNotContainEmail(t *testing.T) {
+	os.Setenv("JWT_SECRET", "test-secret-that-is-long-enough!!")
+	defer os.Unsetenv("JWT_SECRET")
+
+	h := NewHandler(&stubRepo{
+		otp: &repository.OtpCode{
+			ID:        1,
+			Email:     "seeker@kapt.com",
+			Code:      "123456",
+			ExpiresAt: time.Now().Add(5 * time.Minute),
+			Used:      sql.NullBool{Bool: false, Valid: true},
+		},
+	})
+
+	body, _ := json.Marshal(map[string]string{"email": "seeker@kapt.com", "code": "123456"})
+	req := httptest.NewRequest(http.MethodPost, "/auth/verify", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.VerifyOTP(w, req)
+
+	var resp map[string]string
+	json.NewDecoder(w.Body).Decode(&resp)
+
+	// Decode JWT payload without verifying signature — just inspect claims
+	parts := strings.Split(resp["token"], ".")
+	if len(parts) != 3 {
+		t.Fatalf("expected 3 JWT parts, got %d", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("failed to decode JWT payload: %v", err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatalf("failed to unmarshal claims: %v", err)
+	}
+	if _, ok := claims["email"]; ok {
+		t.Fatal("JWT must not contain the email claim (PII exposure)")
+	}
+	if _, ok := claims["sub"]; !ok {
+		t.Fatal("JWT must contain the sub claim")
 	}
 }
 


### PR DESCRIPTION
## Summary

Two security flaws identified in technical review, both fixed in this PR.

### Fix 1 — Critical: OTP Entropy Fallback Removed
`generateRandomCode` previously returned the hardcoded `"123456"` if `crypto/rand` failed to read enough bytes. Any attacker aware of this path could predict the OTP.

- Signature changed to `(string, error)`
- On entropy failure, returns a descriptive error — caller aborts with `HTTP 500`
- No predictable fallback exists anywhere in the code path

### Fix 2 — PII Exposure in JWT Claims
`email` was included in `jwt.MapClaims`. JWTs are base64-encoded, not encrypted — the claim is readable by anyone with the token (browser JS, proxies, logs).

- `email` removed from claims
- `sub` (seeker UUID) is sufficient for all backend identification
- Final claims: `sub`, `iat`, `exp`

### Acknowledged: JWT TTL
24h expiry retained for now. A future spec (`tech-auth-refresh.md`) will cover short-lived access tokens + `POST /auth/refresh` with `HttpOnly` refresh token cookie.

## Test plan

- [x] `TestGenerateRandomCode_ReturnsCorrectLength` — verifies 6 numeric chars, no error
- [x] `TestVerifyOTP_JWTDoesNotContainEmail` — decodes JWT payload, asserts `email` absent, `sub` present
- [x] All existing tests still pass
- [x] `go test ./...` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)