### PR TITLE
style(ui): remove Início nav link and drop 'oficiais' from subtitle

### DIFF
--- a/apps/base/app/page.tsx
+++ b/apps/base/app/page.tsx
@@ -46,7 +46,7 @@ export default function Page() {
 
           {/* ALIGNMENT FIX: Description is now strictly within the same right-aligned flex column */}
           <p className="text-zinc-400 text-xs md:text-sm font-semibold tracking-widest uppercase mb-1">
-            Galerias oficiais de eventos multiesportivos.
+            Galerias de eventos multiesportivos.
           </p>
 
           <span className="text-3xl md:text-5xl font-medium tracking-[0.25em] text-white uppercase font-mono leading-none mb-6">

--- a/apps/base/src/components/Navbar.tsx
+++ b/apps/base/src/components/Navbar.tsx
@@ -2,7 +2,6 @@
 
 export function Navbar() {
     const navLinks = [
-        { name: 'Início', href: '#' },
         { name: 'Coberturas', href: '#' },
         { name: 'Blog', href: '#' },
         { name: 'Sobre', href: '#' }

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -2,7 +2,6 @@
 
 export function Navbar() {
     const navLinks = [
-        { name: 'Início', href: '#' },
         { name: 'Coberturas', href: '#' },
         { name: 'Blog', href: '#' },
         { name: 'Sobre', href: '#' }


### PR DESCRIPTION
## Summary

- Removes `Início` from the navigation menu in both `apps/base` and `apps/web` Navbar components
- Updates the landing page subtitle from `Galerias oficiais de eventos multiesportivos.` → `Galerias de eventos multiesportivos.`

## Files changed

- [apps/base/src/components/Navbar.tsx](apps/base/src/components/Navbar.tsx)
- [apps/web/src/components/Navbar.tsx](apps/web/src/components/Navbar.tsx)
- [apps/base/app/page.tsx](apps/base/app/page.tsx)

## Test plan

- [x] Nav renders with 3 links: Coberturas, Blog, Sobre
- [x] Subtitle reads "Galerias de eventos multiesportivos."

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)