### PR TITLE
feat(ci): add GitHub Actions CI workflow for backend and frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [develop, main]
+  pull_request:
+    branches: [develop, main]
+
+jobs:
+  backend:
+    name: Backend (Go)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: services/go.mod
+          cache-dependency-path: services/go.sum
+
+      - name: Install dependencies
+        working-directory: services
+        run: go mod download
+
+      - name: Build
+        working-directory: services
+        run: go build ./...
+
+      - name: Test
+        working-directory: services
+        run: go test ./...
+
+  frontend:
+    name: Frontend (Next.js)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` with two parallel jobs that run on every push and PR to `develop` and `main`.

## Jobs

**Backend (Go)**
- Go version pinned from `services/go.mod`
- `go mod download` → `go build ./...` → `go test ./...`
- Covers all existing tests in `internal/handler`, `internal/service`

**Frontend (Next.js)**
- Node.js 22, npm cache enabled
- `npm ci` → `npm run build` (runs `turbo run build` across all apps)

## Test plan

- [x] Push to `develop` triggers both jobs
- [x] PR to `develop` shows CI status checks before merge
- [x] Backend job passes `go build ./...` and `go test ./...`
- [x] Frontend job passes `npm run build`

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)