### PR TITLE
feat(api): backend infrastructure and Neon PostgreSQL connection

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
             "version": "1.24"
         }
     },
+    "forwardPorts": [3000, 8080],
     "postCreateCommand": "npm install",
     "remoteEnv": {
         "NEXT_PUBLIC_API_URL": "http://localhost:8080"

--- a/services/cmd/api/main.go
+++ b/services/cmd/api/main.go
@@ -44,11 +44,15 @@ func main() {
 		if err := conn.QueryRowContext(r.Context(), "SELECT 1").Scan(&n); err != nil {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusServiceUnavailable)
-			json.NewEncoder(w).Encode(map[string]string{"status": "error"})
+			if encErr := json.NewEncoder(w).Encode(map[string]string{"status": "error"}); encErr != nil {
+				log.Printf("health encode error: %v", encErr)
+			}
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		if encErr := json.NewEncoder(w).Encode(map[string]string{"status": "ok"}); encErr != nil {
+			log.Printf("health encode error: %v", encErr)
+		}
 	})
 
 	mux.HandleFunc("POST /auth/request", h.RequestOTP)

--- a/services/cmd/api/main.go
+++ b/services/cmd/api/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
@@ -38,8 +39,22 @@ func main() {
 	h := handler.NewHandler(queries)
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+		var n int
+		if err := conn.QueryRowContext(r.Context(), "SELECT 1").Scan(&n); err != nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			json.NewEncoder(w).Encode(map[string]string{"status": "error"})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+	})
+
 	mux.HandleFunc("POST /auth/request", h.RequestOTP)
 	mux.HandleFunc("POST /auth/verify", h.VerifyOTP)
+	mux.HandleFunc("GET /api/v1/photographers", h.ListPhotographers)
+	mux.HandleFunc("POST /api/v1/photographers", h.CreatePhotographer)
 
 	addr := ":8080"
 	fmt.Printf("✅ Kapt API listening on %s\n", addr)

--- a/services/internal/handler/auth_test.go
+++ b/services/internal/handler/auth_test.go
@@ -66,6 +66,9 @@ func (s *stubRepo) GetOccurrenceBySlug(_ context.Context, _ string) (repository.
 func (s *stubRepo) ListOccurrencesByPhotographer(_ context.Context, _ uuid.UUID) ([]repository.ListOccurrencesByPhotographerRow, error) {
 	return nil, nil
 }
+func (s *stubRepo) ListPhotographers(_ context.Context) ([]repository.Photographer, error) {
+	return nil, nil
+}
 
 func TestVerifyOTP_ValidCode_ReturnsJWT(t *testing.T) {
 	os.Setenv("JWT_SECRET", "test-secret-that-is-long-enough!!")

--- a/services/internal/handler/photographers.go
+++ b/services/internal/handler/photographers.go
@@ -80,7 +80,9 @@ func (h *Handler) CreatePhotographer(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil || payload.Name == "" || payload.Email == "" {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "name and email are required"})
+		if err := json.NewEncoder(w).Encode(map[string]string{"error": "name and email are required"}); err != nil {
+			http.Error(w, "internal server error", http.StatusInternalServerError)
+		}
 		return
 	}
 

--- a/services/internal/handler/photographers.go
+++ b/services/internal/handler/photographers.go
@@ -1,0 +1,109 @@
+package handler
+
+import (
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/kapt/api/internal/repository"
+	"github.com/shopspring/decimal"
+)
+
+type photographerResponse struct {
+	ID                      uuid.UUID        `json:"id"`
+	Name                    string           `json:"name"`
+	Email                   string           `json:"email"`
+	Bio                     *string          `json:"bio"`
+	StripeAccountID         *string          `json:"stripe_account_id"`
+	CreatedAt               time.Time        `json:"created_at"`
+	UpdatedAt               time.Time        `json:"updated_at"`
+	IsFounder               bool             `json:"is_founder"`
+	IsPioneer               bool             `json:"is_pioneer"`
+	FounderDeadline         *time.Time       `json:"founder_deadline"`
+	TotalRevenueAccumulated decimal.Decimal  `json:"total_revenue_accumulated"`
+	CommissionRate          decimal.Decimal  `json:"commission_rate"`
+}
+
+func toPhotographerResponse(p repository.Photographer) photographerResponse {
+	r := photographerResponse{
+		ID:                      p.ID,
+		Name:                    p.Name,
+		Email:                   p.Email,
+		CreatedAt:               p.CreatedAt,
+		UpdatedAt:               p.UpdatedAt,
+		IsFounder:               p.IsFounder,
+		IsPioneer:               p.IsPioneer,
+		TotalRevenueAccumulated: p.TotalRevenueAccumulated,
+		CommissionRate:          p.CommissionRate,
+	}
+	if p.Bio.Valid {
+		r.Bio = &p.Bio.String
+	}
+	if p.StripeAccountID.Valid {
+		r.StripeAccountID = &p.StripeAccountID.String
+	}
+	if p.FounderDeadline.Valid {
+		r.FounderDeadline = &p.FounderDeadline.Time
+	}
+	return r
+}
+
+func (h *Handler) ListPhotographers(w http.ResponseWriter, r *http.Request) {
+	photographers, err := h.repo.ListPhotographers(r.Context())
+	if err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	resp := make([]photographerResponse, len(photographers))
+	for i, p := range photographers {
+		resp[i] = toPhotographerResponse(p)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}
+}
+
+type createPhotographerPayload struct {
+	Name            string `json:"name"`
+	Email           string `json:"email"`
+	Bio             string `json:"bio"`
+	StripeAccountID string `json:"stripe_account_id"`
+}
+
+func (h *Handler) CreatePhotographer(w http.ResponseWriter, r *http.Request) {
+	var payload createPhotographerPayload
+	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil || payload.Name == "" || payload.Email == "" {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "name and email are required"})
+		return
+	}
+
+	params := repository.CreatePhotographerParams{
+		Name:  payload.Name,
+		Email: payload.Email,
+	}
+	if payload.Bio != "" {
+		params.Bio = sql.NullString{String: payload.Bio, Valid: true}
+	}
+	if payload.StripeAccountID != "" {
+		params.StripeAccountID = sql.NullString{String: payload.StripeAccountID, Valid: true}
+	}
+
+	photographer, err := h.repo.CreatePhotographer(r.Context(), params)
+	if err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	if err := json.NewEncoder(w).Encode(toPhotographerResponse(photographer)); err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}
+}

--- a/services/internal/repository/photographers.go
+++ b/services/internal/repository/photographers.go
@@ -1,0 +1,35 @@
+package repository
+
+import (
+	"context"
+)
+
+const listPhotographers = `
+SELECT id, name, email, bio, stripe_account_id, created_at, updated_at,
+       is_founder, is_pioneer, founder_deadline, total_revenue_accumulated, commission_rate
+FROM photographers
+ORDER BY created_at DESC
+`
+
+func (q *Queries) ListPhotographers(ctx context.Context) ([]Photographer, error) {
+	rows, err := q.db.QueryContext(ctx, listPhotographers)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var items []Photographer
+	for rows.Next() {
+		var i Photographer
+		if err := rows.Scan(
+			&i.ID, &i.Name, &i.Email, &i.Bio, &i.StripeAccountID,
+			&i.CreatedAt, &i.UpdatedAt,
+			&i.IsFounder, &i.IsPioneer, &i.FounderDeadline,
+			&i.TotalRevenueAccumulated, &i.CommissionRate,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	return items, rows.Err()
+}

--- a/services/internal/repository/querier.go
+++ b/services/internal/repository/querier.go
@@ -21,6 +21,7 @@ type Querier interface {
 	// Retrieves a seeker by their unique email address
 	GetSeekerByEmail(ctx context.Context, email string) (Seeker, error)
 	ListOccurrencesByPhotographer(ctx context.Context, photographerID uuid.UUID) ([]ListOccurrencesByPhotographerRow, error)
+	ListPhotographers(ctx context.Context) ([]Photographer, error)
 	// Marks an OTP code as consumed to prevent replay attacks
 	MarkOTPUsed(ctx context.Context, id int32) error
 	// Accumulates revenue after each sale and returns the updated tier row

--- a/services/sqlc/query/photographers.sql
+++ b/services/sqlc/query/photographers.sql
@@ -1,3 +1,9 @@
+-- name: ListPhotographers :many
+SELECT id, name, email, bio, stripe_account_id, created_at, updated_at,
+       is_founder, is_pioneer, founder_deadline, total_revenue_accumulated, commission_rate
+FROM photographers
+ORDER BY created_at DESC;
+
 -- name: GetPhotographerTier :one
 -- Fetches tier status and effective commission rate for payout calculation
 SELECT id, is_founder, is_pioneer, founder_deadline,


### PR DESCRIPTION
## Summary

Closes #56

- Fix `x509: certificate signed by unknown authority` by removing empty `sslrootcert=` from `DB_SOURCE` (`sslmode=require` is sufficient for Neon)
- Add `GET /health` endpoint that runs `SELECT 1` and returns `{"status":"ok"}`
- Add `GET /api/v1/photographers` and `POST /api/v1/photographers` endpoints
- Implement `ListPhotographers` repository method (manual sqlc-style, query added to `photographers.sql`)
- Add `photographerResponse` DTO to serialize `sql.NullString`/`sql.NullTime` as plain values instead of `{"String":"...","Valid":true}`
- Add `forwardPorts: [3000, 8080]` to `devcontainer.json`

## Test plan

- [x] `GET /health` returns `{"status":"ok"}`
- [x] `POST /api/v1/photographers` with `{"name":"...","email":"..."}` returns `201` with created record
- [x] `GET /api/v1/photographers` returns the created photographer with flat JSON (no `NullString` objects)

🤖 Generated with [Claude Code](https://claude.com/claude-code)