### PR TITLE
fix(api): correct HTTP route handling and add local env helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,10 +95,11 @@ O backend requer duas variáveis de ambiente:
 
 ```bash
 cd /workspace/services
-DB_SOURCE="postgresql://kapt_admin:kapt_password@localhost:5432/kapt_local?sslmode=disable" \
-JWT_SECRET="meu-segredo-super-secreto-kapt!!" \
+cp .env.example .env
 go run ./cmd/api
 ```
+
+> If you want to override values, set `DB_SOURCE` or `JWT_SECRET` in your shell before running.
 
 ---
 

--- a/services/.env.example
+++ b/services/.env.example
@@ -1,0 +1,5 @@
+# Local development environment variables for the Kapt API
+# Copy this file to services/.env before running the backend.
+
+DB_SOURCE=postgresql://kapt_admin:kapt_password@localhost:5432/kapt_local?sslmode=disable
+JWT_SECRET=meu-segredo-super-secreto-kapt!!

--- a/services/cmd/api/main.go
+++ b/services/cmd/api/main.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"bufio"
 	"database/sql"
 	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/kapt/api/internal/handler"
 	"github.com/kapt/api/internal/repository"
@@ -14,6 +16,12 @@ import (
 )
 
 func main() {
+	if err := loadEnvFile(".env"); err != nil {
+		if !os.IsNotExist(err) {
+			log.Printf("warning: could not load .env file: %v", err)
+		}
+	}
+
 	dbSource := os.Getenv("DB_SOURCE")
 	if dbSource == "" {
 		dbSource = "postgresql://postgres:postgres@db:5432/kapt?sslmode=disable"
@@ -39,7 +47,14 @@ func main() {
 	h := handler.NewHandler(queries)
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("GET /health", func(w http.ResponseWriter, r *http.Request) {
+
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.Header().Set("Allow", http.MethodGet)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
 		var n int
 		if err := conn.QueryRowContext(r.Context(), "SELECT 1").Scan(&n); err != nil {
 			w.Header().Set("Content-Type", "application/json")
@@ -55,14 +70,73 @@ func main() {
 		}
 	})
 
-	mux.HandleFunc("POST /auth/request", h.RequestOTP)
-	mux.HandleFunc("POST /auth/verify", h.VerifyOTP)
-	mux.HandleFunc("GET /api/v1/photographers", h.ListPhotographers)
-	mux.HandleFunc("POST /api/v1/photographers", h.CreatePhotographer)
+	mux.HandleFunc("/auth/request", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		h.RequestOTP(w, r)
+	})
+
+	mux.HandleFunc("/auth/verify", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.Header().Set("Allow", http.MethodPost)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		h.VerifyOTP(w, r)
+	})
+
+	mux.HandleFunc("/api/v1/photographers", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			h.ListPhotographers(w, r)
+		case http.MethodPost:
+			h.CreatePhotographer(w, r)
+		default:
+			w.Header().Set("Allow", http.MethodGet+", "+http.MethodPost)
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
 
 	addr := ":8080"
 	fmt.Printf("✅ Kapt API listening on %s\n", addr)
 	if err := http.ListenAndServe(addr, mux); err != nil {
 		log.Fatalf("server error: %v", err)
 	}
+}
+
+func loadEnvFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+		value = strings.Trim(value, " \t\"'")
+		if key == "" {
+			continue
+		}
+
+		if os.Getenv(key) == "" {
+			os.Setenv(key, value)
+		}
+	}
+
+	return scanner.Err()
 }

--- a/services/cmd/api/main_test.go
+++ b/services/cmd/api/main_test.go
@@ -1,8 +1,70 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
-func TestAPIEnvironment(t *testing.T) {
-	// Placeholder test to verify that the testing environment for the API cmd is set up correctly.
-	t.Log("API cmd environment test passed.")
+func TestLoadEnvFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, ".env")
+	content := "DB_SOURCE=postgresql://user:pass@localhost:5432/kapt_local?sslmode=disable\nJWT_SECRET=test-secret-1234567890\n"
+	if err := os.WriteFile(filePath, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write temp .env: %v", err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer os.Chdir(oldWd)
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	os.Unsetenv("DB_SOURCE")
+	os.Unsetenv("JWT_SECRET")
+
+	if err := loadEnvFile(".env"); err != nil {
+		t.Fatalf("loadEnvFile failed: %v", err)
+	}
+
+	if got := os.Getenv("DB_SOURCE"); got != "postgresql://user:pass@localhost:5432/kapt_local?sslmode=disable" {
+		t.Fatalf("expected DB_SOURCE from .env, got %q", got)
+	}
+	if got := os.Getenv("JWT_SECRET"); got != "test-secret-1234567890" {
+		t.Fatalf("expected JWT_SECRET from .env, got %q", got)
+	}
+}
+
+func TestLoadEnvFilePreservesExistingEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, ".env")
+	content := "JWT_SECRET=from-file-secret\n"
+	if err := os.WriteFile(filePath, []byte(content), 0o600); err != nil {
+		t.Fatalf("failed to write temp .env: %v", err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get cwd: %v", err)
+	}
+	defer os.Chdir(oldWd)
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("failed to chdir: %v", err)
+	}
+
+	os.Setenv("JWT_SECRET", "existing-secret")
+	defer os.Unsetenv("JWT_SECRET")
+
+	if err := loadEnvFile(".env"); err != nil {
+		t.Fatalf("loadEnvFile failed: %v", err)
+	}
+
+	if got := os.Getenv("JWT_SECRET"); got != "existing-secret" {
+		t.Fatalf("expected existing JWT_SECRET to win, got %q", got)
+	}
 }


### PR DESCRIPTION
Fix backend route handling for `/api/v1/photographers` and add a local services `.env.example` helper.

Closes #72